### PR TITLE
Fix/edit memberinfo GitHub and nickname

### DIFF
--- a/semi-project-moco/src/main/java/org/kosta/moco/controller/EditMyInfoFormSubmitController.java
+++ b/semi-project-moco/src/main/java/org/kosta/moco/controller/EditMyInfoFormSubmitController.java
@@ -21,7 +21,7 @@ public class EditMyInfoFormSubmitController implements Controller {
 		//사용자가 입력한 수정값을 받아와서 MemberVO 타입의 Emov를 생성해주고. 
 		String email = request.getParameter("email");
 		String nickname=request.getParameter("nickname");
-		String github=request.getParameter("github");
+		String github= "www.github.com/" + request.getParameter("github");
 		String password=request.getParameter("password");
 		MemberVO Emov = new MemberVO(email, password, nickname, github);
 		

--- a/semi-project-moco/src/main/webapp/edit-memberinfo.jsp
+++ b/semi-project-moco/src/main/webapp/edit-memberinfo.jsp
@@ -91,7 +91,7 @@ function passwordChanged() {
 			<tbody>
 				<tr>
 					<td style="background-color: #fafafafa; text-align:center; "><h5>닉네임</h5></td>
-					<td><input name="nickname" class="form-control" type="text" id="nickname" size="20" value="${sessionScope.loginMemberVO.nickname}" onkeyup="checkNickname()"></td>
+					<td><input name="nickname" class="form-control" type="text" id="nickname" size="20" value="${sessionScope.loginMemberVO.nickname}" required="required" onkeyup="checkNickname()"></td>
 					    <input id="nicknameFlag" type="hidden" value="">
 						<p id="duplicateResult" style="font-size: 13px"><p>	    
 				</tr>
@@ -107,7 +107,7 @@ function passwordChanged() {
 						<span class="input-group-text" id="basic-addon3">www.github.com/</span>
 					</div>
 					<c:set var="githubUserName" value="${sessionScope.loginMemberVO.github}"/>
-					<td><input id="basic-url" aria-describedby="basic-addon3" name="github" class="form-control" type="text" size="20" value="${fn:substring(githubUserName,15,fn:length(githubUserName)  ) }"></td>
+					<td><input id="basic-url" aria-describedby="basic-addon3" name="github" class="form-control" type="text" size="20" required="required"  value="${fn:substring(githubUserName,15,fn:length(githubUserName)  ) }"></td>
 				</tr>
 			</tbody>
 		</table>
@@ -118,7 +118,7 @@ function passwordChanged() {
 				<tr>
 					<div class="input-group mb-3">
 						<td style="background-color: #fafafafa; text-align:center; "><h5>비밀번호</h5></td>
-						<td><input name="password" id="pass" class="form-control" type="password" maxlength="100" size="20" value="${sessionScope.loginMemberVO.password}" onkeyup="return passwordChanged();"></td>
+						<td><input name="password" id="pass" class="form-control" type="password" maxlength="100" size="20" required="required"  value="${sessionScope.loginMemberVO.password}" onkeyup="return passwordChanged();"></td>
 						<div class="input-group-append">
 							<span id="strength" class="input-group-text">보안</span>
 						</div>
@@ -136,7 +136,7 @@ function passwordChanged() {
 				<tr>
 					<div class="input-group mb-3">
 						<td style="background-color: #fafafafa; text-align:center; "><h5>비밀번호 확인</h5></td>
-						<td><input name="confirmPassword" id="confirmPass" class="form-control" type="password" size="20" value="${sessionScope.loginMemberVO.password}" onkeyup="checkPassword()"></td>
+						<td><input name="confirmPassword" id="confirmPass" class="form-control" type="password" size="20" required="required"  value="${sessionScope.loginMemberVO.password}" onkeyup="checkPassword()"></td>
 					</div>
 					<div>
 						<p id="confirmResult" style="font-size: 13px"><p>

--- a/semi-project-moco/src/main/webapp/edit-memberinfo.jsp
+++ b/semi-project-moco/src/main/webapp/edit-memberinfo.jsp
@@ -14,6 +14,7 @@ function checkRegForm() {
 	let nickname = document.getElementById("nickname");
 	let nicknameFlag = document.getElementById("nicknameFlag");
 	if(nickname.value != nicknameFlag.value) {
+		if(nickname.value == loginMemberVO.nickname) return;
 		alert("중복된 닉네임 입니다.\n사용 가능한 닉네임으로 변경해주세요");
 		return false;
 	}

--- a/semi-project-moco/src/main/webapp/header.jsp
+++ b/semi-project-moco/src/main/webapp/header.jsp
@@ -14,7 +14,7 @@
 					</form>
 				</c:when>
 				<c:otherwise>
-					<span class="navbar-text">${sessionScope.mvo.nickname}님&nbsp;&nbsp;
+					<span class="navbar-text">${sessionScope.loginMemberVO.nickname}님&nbsp;&nbsp;
 						, 안녕하세요.&nbsp;&nbsp;&nbsp;</span>
 					<form action="LogoutController.do" method="post" id="logoutForm"></form>
 					<button class="btn btn-primary me-md-2" onclick="logout()"


### PR DESCRIPTION
회원 정보 수정 페이지에서

1. 수정 전의 닉네임이 헤더에 뜨던 것을 수정 후의 닉네임이 뜨도록 수정했습니다. 
2. 닉네임 수정 안하고 그대로 둔 상태에서 '수정하기' 버튼 클릭 시 중복 처리가 되지 않도록 해결했습니다.
3. 깃허브 주소 수정 시 유저네임만 저장되던것을 깃허브 풀 주소로 저장되게 했습니다.